### PR TITLE
Enhance landing and order pages

### DIFF
--- a/lensevent/package-lock.json
+++ b/lensevent/package-lock.json
@@ -11,6 +11,7 @@
         "@stripe/react-stripe-js": "^2.2.2",
         "@stripe/stripe-js": "^2.2.2",
         "react": "^18.2.0",
+        "react-datepicker": "^8.4.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3"
       },
@@ -901,6 +902,59 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
+      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.12.tgz",
+      "integrity": "sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.3",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.3.tgz",
+      "integrity": "sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1598,6 +1652,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1653,6 +1716,16 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2515,6 +2588,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.4.0.tgz",
+      "integrity": "sha512-6nPDnj8vektWCIOy9ArS3avus9Ndsyz5XgFCJ7nBxXASSpBdSL6lG9jzNNmViPOAOPh6T5oJyGaXuMirBLECag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.3",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -2710,6 +2798,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/lensevent/package.json
+++ b/lensevent/package.json
@@ -10,11 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
     "@stripe/react-stripe-js": "^2.2.2",
-    "@stripe/stripe-js": "^2.2.2"
+    "@stripe/stripe-js": "^2.2.2",
+    "react": "^18.2.0",
+    "react-datepicker": "^8.4.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/lensevent/src/pages/CheckoutPage.css
+++ b/lensevent/src/pages/CheckoutPage.css
@@ -4,13 +4,7 @@
   padding: 1rem;
 }
 
-.checkout-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.checkout-form button {
+.checkout-button {
   background-color: #ffc107;
   color: black;
   padding: 0.5rem 1rem;

--- a/lensevent/src/pages/CheckoutPage.jsx
+++ b/lensevent/src/pages/CheckoutPage.jsx
@@ -1,39 +1,22 @@
 import { useLocation } from 'react-router-dom'
-import { loadStripe } from '@stripe/stripe-js'
-import { Elements, useStripe, useElements, CardElement } from '@stripe/react-stripe-js'
 import './CheckoutPage.css'
 
-const stripePromise = loadStripe('pk_test_TODO_REPLACE')
-
-function CheckoutForm({ price }) {
-  const stripe = useStripe()
-  const elements = useElements()
-
-  async function handleSubmit(e) {
-    e.preventDefault()
-    if (!stripe || !elements) return
-    // Placeholder: normally you would create paymentIntent on server
-    alert(`Simulated betaling van €${price.toFixed(2)}`)
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="checkout-form">
-      <CardElement />
-      <button type="submit" disabled={!stripe}>Betaal nu</button>
-    </form>
-  )
-}
+const STRIPE_CHECKOUT_URL = 'https://example.com/stripe-checkout'
 
 export default function CheckoutPage() {
   const { state } = useLocation()
   const price = state?.price || 0
 
+  function redirect() {
+    window.location.href = STRIPE_CHECKOUT_URL
+  }
+
   return (
     <div className="checkout">
       <h2>Betaal totaalprijs van €{price.toFixed(2)}</h2>
-      <Elements stripe={stripePromise}>
-        <CheckoutForm price={price} />
-      </Elements>
+      <button onClick={redirect} className="checkout-button">
+        Naar betaling
+      </button>
     </div>
   )
 }

--- a/lensevent/src/pages/LandingPage.css
+++ b/lensevent/src/pages/LandingPage.css
@@ -1,8 +1,25 @@
 .landing {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+}
+
+.landing .hero {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.process {
+  text-align: left;
+  margin-top: 2rem;
+}
+
+.process ol {
+  padding-left: 1.5rem;
 }
 
 .order-button {

--- a/lensevent/src/pages/LandingPage.jsx
+++ b/lensevent/src/pages/LandingPage.jsx
@@ -4,17 +4,24 @@ import './LandingPage.css'
 export default function LandingPage() {
   return (
     <div className="landing">
+      <img
+        className="hero"
+        src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=1200&q=60"
+        alt="Photobooth" />
       <h1>LENSEVENT Photobooth Verhuur</h1>
       <p>
         Huur onze photobooths voor jouw evenement. Bestel online, betaal en kies
-        een thema. De eigenaar neemt vervolgens contact op om het fotothema
-        volledig op maat uit te werken.
+        een thema. Wij nemen vervolgens contact op om het fotothema volledig op
+        maat uit te werken.
       </p>
-      <p>
-        Het proces is eenvoudig: selecteer je dagen, betaal veilig online en wij
-        regelen de rest. Op de dag van het event wordt de photobooth geleverd,
-        opgezet en achteraf terug opgehaald.
-      </p>
+      <div className="process">
+        <h2>Hoe werkt het?</h2>
+        <ol>
+          <li>Selecteer de gewenste dagen en een fotothema.</li>
+          <li>Betaal veilig online via onze betaalpagina.</li>
+          <li>Wij leveren en installeren de photobooth op je event.</li>
+        </ol>
+      </div>
       <Link className="order-button" to="/order">Bestel nu</Link>
     </div>
   )

--- a/lensevent/src/pages/OrderPage.css
+++ b/lensevent/src/pages/OrderPage.css
@@ -1,9 +1,20 @@
 .order {
-  max-width: 600px;
+  max-width: 700px;
   margin: 0 auto;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.order .intro img {
+  width: 100%;
+  max-height: 300px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 1rem;
 }
 
 .order label {


### PR DESCRIPTION
## Summary
- redesign landing page with hero image and process section
- add calendar, time selectors and address autocomplete to order form
- calculate distance without Google APIs
- simplify Stripe checkout to redirect to an external page
- style updates for order and checkout pages
- add `react-datepicker` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848700281b0832a9601bb9a4cefea10